### PR TITLE
Fixed bug when selecting a coin sometimes would display the Model's name

### DIFF
--- a/UWP/UserControls/CoinAutoSuggestBox.xaml
+++ b/UWP/UserControls/CoinAutoSuggestBox.xaml
@@ -21,6 +21,7 @@
         SuggestionChosen="AutoSuggestBox_SuggestionChosen"
         QueryIcon="Find"
         QuerySubmitted="AutoSuggestBox_QuerySubmitted"
+		UpdateTextOnSelect="False"
         VerticalAlignment="Top"
         Width="130">
         <AutoSuggestBox.ItemTemplate>


### PR DESCRIPTION
This PR fixes the Issue #28 as commented on the issue itself.